### PR TITLE
Use TAG to support <script src=""> cases

### DIFF
--- a/runfile.js
+++ b/runfile.js
@@ -58,7 +58,7 @@ build.app.scripts = {
     console.log(`\n[${colourType(type)}: ${colourOutput(output)}] ${colourInfo(desc)}`);
 
     run(`mkdirp ${config.assetsDir}/${config.scriptsDir}`);
-    return run(`browserify ${input} -p browserify-derequire -s tag -t [ babelify ] -t [ hbsfy ] -p [ tinyify ] -o ${output} -v`, {async: true});
+    return run(`browserify ${input} -p browserify-derequire -s TAG -t [ babelify ] -t [ hbsfy ] -p [ tinyify ] -o ${output} -v`, {async: true});
   },
   async quickTag() {
     const input = "src/js/tag.js";


### PR DESCRIPTION
This change should ensure that usage of TAG when included via `<script src=` mirrors the behavior described in the README when imported as a library.